### PR TITLE
added the type "module" to the package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Create a snapshot of a version materialized LDES ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "type": "module",
   "scripts": {
     "test": "jest",
     "build": "rm -rf dist/; tsc",


### PR DESCRIPTION
the package was not working, and providing the error, 'require() of ES Module from not supported.'